### PR TITLE
Update fields referring to Nexmo to now be Vonage due to rebranding

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,5 +1,5 @@
 // This package offers a simple API wrapper and helper functions to get
-// users started with the Nexmo APIs
+// users started with the Vonage APIs
 // Pull requests, issues and comments are all welcome and gratefully received
 
 package vonage

--- a/docs/examples/ncco.md
+++ b/docs/examples/ncco.md
@@ -49,7 +49,7 @@ Send a `record` action to start a recording:
     record := ncco.RecordAction{BeepStart: true}
 ```
 
-When the recording completes, Nexmo sends a webhook containing the recording URL so that you can download the file.
+When the recording completes, Vonage sends a webhook containing the recording URL so that you can download the file.
 
 ## Conversation Action
 
@@ -76,6 +76,4 @@ Connects the current call to another endpoint (currently only phone is supported
     endpoint := []ncco.PhoneEndpoint{Number: "44777000777"}
 	connect := ncco.ConnectAction{Endpoint: endpoint, From: "44777000888"}
 ```
-The `from` field when connecting to a phone endpoint should be a Nexmo number that you own.
-
-
+The `from` field when connecting to a phone endpoint should be a Vonage number that you own.

--- a/docs/examples/tips.md
+++ b/docs/examples/tips.md
@@ -26,7 +26,7 @@ func main() {
 	smsClient := vonage.NewSMSClient(auth)
     smsClient.Config.BasePath = "http://localhost:4010"
 
-	response, err := smsClient.Send("NexmoGolang", "44777000777", "This is a message from golang", vonage.SMSOpts{})
+	response, err := smsClient.Send("VonageGolang", "44777000777", "This is a message from golang", vonage.SMSOpts{})
 
 	if err != nil {
 		panic(err)
@@ -53,5 +53,3 @@ Many of our APIs use dates but they come from the API as strings that Go underst
 ```
 
 You can then go ahead and use the time object as you usually would.
-
-

--- a/docs/examples/voice.md
+++ b/docs/examples/voice.md
@@ -85,6 +85,7 @@ func main() {
 ```
 
 This is useful for answering a call (as shown above) but also for handling webhooks that expect an NCCO response such as notify, input, and so on.
+
 ## List all Calls
 
 A list of all the calls associated with your account.

--- a/sms.go
+++ b/sms.go
@@ -44,7 +44,7 @@ type Sms struct {
 }
 
 // Send an SMS. Give some text to send and the number to send to - there are
-// some restrictions on what you can send from, to be safe try using a Nexmo
+// some restrictions on what you can send from, to be safe try using a Vonage
 // number associated with your account
 func (client *SMSClient) Send(from string, to string, text string, opts SMSOpts) (Sms, error) {
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -33,7 +33,7 @@ func TestVerifyRequest(t *testing.T) {
 
 	auth := CreateAuthFromKeySecret("12345678", "456")
 	client := NewVerifyClient(auth)
-	response, _, _ := client.Request("44777000777", "NexmoGoTest", VerifyOpts{})
+	response, _, _ := client.Request("44777000777", "VonageGoTest", VerifyOpts{})
 
 	message := "Request ID: " + response.RequestId
 	if message != "Request ID: abcdef0123456789abcdef0123456789" {
@@ -65,7 +65,7 @@ func TestVerifyRequestConcurrent(t *testing.T) {
 
 	auth := CreateAuthFromKeySecret("12345678", "456")
 	client := NewVerifyClient(auth)
-	_, errResp, _ := client.Request("44777000777", "NexmoGoTest", VerifyOpts{})
+	_, errResp, _ := client.Request("44777000777", "VonageGoTest", VerifyOpts{})
 
 	message := "Error status " + errResp.Status + ": " + errResp.ErrorText
 	if message != "Error status 10: Concurrent verifications to the same number are not allowed" {
@@ -90,7 +90,7 @@ Go away
 
 	auth := CreateAuthFromKeySecret("12345678", "456")
 	client := NewVerifyClient(auth)
-	_, _, err := client.Request("44777000777", "NexmoGoTest", VerifyOpts{})
+	_, _, err := client.Request("44777000777", "VonageGoTest", VerifyOpts{})
 
 	if err == nil {
 		t.Errorf("This should have produced an error")
@@ -177,7 +177,7 @@ func TestVerifySearch(t *testing.T) {
     "sender_id": "verify",
     "date_submitted": "2020-01-01 12:00:00",
     "date_finalized": "2020-01-01 12:00:00",
-    "checks": 
+    "checks":
 
 [
 
@@ -204,7 +204,7 @@ func TestVerifySearch(t *testing.T) {
 "currency": "EUR",
 "status": "SUCCESS",
 "estimated_price_messages_sent": "0.06660000",
-"events": 
+"events":
 [
 
 {


### PR DESCRIPTION
Several fields in the SDK were still calling the phone numbers Nexmo numbers, for example, updated these to be Vonage numbers.