### PR TITLE
Set a consistent user agent with a single place to update it

### DIFF
--- a/application.go
+++ b/application.go
@@ -3,7 +3,6 @@ package vonage
 import (
 	"context"
 	"encoding/json"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/application"
@@ -24,7 +23,7 @@ func NewApplicationClient(Auth Auth) *ApplicationClient {
 	client.apiSecret = creds[1]
 
 	client.Config = application.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	return client
 }
 

--- a/number.go
+++ b/number.go
@@ -3,7 +3,6 @@ package vonage
 import (
 	"context"
 	"encoding/json"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/number"
@@ -25,7 +24,7 @@ func NewNumbersClient(Auth Auth) *NumbersClient {
 
 	// Use a default set of config but make it accessible
 	client.Config = number.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	transport := &APITransport{APISecret: client.apiSecret}
 	client.Config.HTTPClient = transport.Client()
 	return client

--- a/numberinsight.go
+++ b/numberinsight.go
@@ -2,7 +2,6 @@ package vonage
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/numberinsight"
@@ -23,7 +22,7 @@ func NewNumberInsightClient(Auth Auth) *NumberInsightClient {
 	client.apiSecret = creds[1]
 
 	client.Config = numberinsight.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	return client
 }
 

--- a/sms.go
+++ b/sms.go
@@ -3,7 +3,6 @@ package vonage
 import (
 	"context"
 	"errors"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/sms"
@@ -25,7 +24,7 @@ func NewSMSClient(Auth Auth) *SMSClient {
 
 	// Use a default set of config but make it accessible
 	client.Config = sms.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	return client
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,12 @@
+package vonage
+
+import "runtime"
+
+func GetVersion() string {
+	return "0.12.1"
+}
+
+func GetUserAgent() string {
+	user_agent := "vonage-go/" + GetVersion() + " Go/" + runtime.Version()
+	return user_agent
+}

--- a/verify.go
+++ b/verify.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/verify"
@@ -25,7 +24,7 @@ func NewVerifyClient(Auth Auth) *VerifyClient {
 	client.apiSecret = creds[1]
 
 	client.Config = verify.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	return client
 }
 

--- a/voice.go
+++ b/voice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"runtime"
 
 	"github.com/antihax/optional"
 	"github.com/vonage/vonage-go-sdk/internal/voice"
@@ -24,7 +23,7 @@ func NewVoiceClient(Auth Auth) *VoiceClient {
 	client.JWT = creds[0]
 
 	client.Config = voice.NewConfiguration()
-	client.Config.UserAgent = "vonage-go/0.15-dev Go/" + runtime.Version()
+	client.Config.UserAgent = GetUserAgent()
 	client.Config.AddDefaultHeader("Authorization", "Bearer "+client.JWT)
 	return client
 }


### PR DESCRIPTION
We had a hardcoded user agent header (and it wasn't even hardcoded to the correct value). This adds a utils file for common functionality and adds both a version function and a user agent function (that uses the version function) so we only need to update in one place when we release.