### PR TITLE
added missing sender id option

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -71,6 +71,10 @@ func (client *VerifyClient) Request(number string, brand string, opts VerifyOpts
 		verifyOpts.WorkflowId = optional.NewInt32(opts.WorkflowID)
 	}
 
+	if opts.SenderID != "" {
+		verifyOpts.SenderId = optional.NewString(opts.SenderID)
+	}
+
 	// we need context for the API key
 	ctx := context.WithValue(context.Background(), verify.ContextAPIKey, verify.APIKey{
 		Key: client.apiKey,


### PR DESCRIPTION
At the moment if you set the Sender ID option in VerifyOpts struct it is ignored.
I found that it was missing from transformation in verify.go and I have added that.