### PR TITLE
SMS Error Handling

### DIFF
--- a/docs/examples/sms.md
+++ b/docs/examples/sms.md
@@ -23,17 +23,19 @@ import (
 )
 
 func main() {
-	auth := vonage.CreateAuthFromKeySecret(API_KEY, API_SECRET)
-	smsClient := vonage.NewSMSClient(auth)
-	response, err := smsClient.Send("44777000000", "44777000777", "This is a message from golang", vonage.SMSOpts{})
+    auth := vonage.CreateAuthFromKeySecret(API_KEY, API_SECRET)
+    smsClient := vonage.NewSMSClient(auth)
+    response, errResp, err := smsClient.Send("44777000000", "44777000777", "This is a message from golang", vonage.SMSOpts{})
 
-	if err != nil {
-		panic(err)
-	}
+    if err != nil {
+        panic(err)
+    }
 
-	if response.Messages[0].Status == "0" {
-		fmt.Println("Account Balance: " + response.Messages[0].RemainingBalance)
-	}
+    if response.Messages[0].Status == "0" {
+        fmt.Println("Account Balance: " + response.Messages[0].RemainingBalance)
+    } else {
+        fmt.Println("Error code " + errResp.Messages[0].Status + ": " + errResp.Messages[0].ErrorText)
+    }
 }
 ```
 
@@ -51,17 +53,19 @@ import (
 )
 
 func main() {
-	auth := vonage.CreateAuthFromKeySecret(API_KEY, API_SECRET)
-	smsClient := vonage.NewSMSClient(auth)
-	response, err := smsClient.Send("44777000000", "44777000777", "こんにちは世界", vonage.SMSOpts{Type: "unicode"})
+    auth := vonage.CreateAuthFromKeySecret(API_KEY, API_SECRET)
+    smsClient := vonage.NewSMSClient(auth)
+    response, errResp, err := smsClient.Send("44777000000", "44777000777", "こんにちは世界", vonage.SMSOpts{Type: "unicode"})
 
-	if err != nil {
-		panic(err)
-	}
+    if err != nil {
+        panic(err)
+    }
 
-	if response.Messages[0].Status == "0" {
-		fmt.Println("Account Balance: " + response.Messages[0].RemainingBalance)
-	}
+    if response.Messages[0].Status == "0" {
+        fmt.Println("Account Balance: " + response.Messages[0].RemainingBalance)
+    } else {
+        fmt.Println("Error code " + errResp.Messages[0].Status + ": " + errResp.Messages[0].ErrorText)
+    }
 }
 ```
 

--- a/examples/cli/vongo/cmd/sms.go
+++ b/examples/cli/vongo/cmd/sms.go
@@ -20,8 +20,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/vonage/vonage-go-sdk"
 	"github.com/spf13/cobra"
+	"github.com/vonage/vonage-go-sdk"
 )
 
 // smsCmd represents the sms command
@@ -51,7 +51,7 @@ use these features to get started and/or test your setup`,
 		auth := vonage.CreateAuthFromKeySecret(Key, Secret)
 		smsClient := vonage.NewSMSClient(auth)
 
-		response, err := smsClient.Send(From, To, Message, vonage.SMSOpts{})
+		response, _, err := smsClient.Send(From, To, Message, vonage.SMSOpts{})
 
 		if err != nil {
 			panic(err)

--- a/internal/sms/api_default.go
+++ b/internal/sms/api_default.go
@@ -11,12 +11,15 @@
 package sms
 
 import (
+	"bytes"
 	_context "context"
+	"fmt"
+	"io/ioutil"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
+
 	"github.com/antihax/optional"
 )
 
@@ -195,6 +198,10 @@ func (a *DefaultApiService) SendAnSms(ctx _context.Context, format string, apiKe
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
+
+	// hack to reinstate the body in case we need it
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}

--- a/number.go
+++ b/number.go
@@ -30,6 +30,12 @@ func NewNumbersClient(Auth Auth) *NumbersClient {
 	return client
 }
 
+// NumbersResponse is the response format for the Numbers API
+type NumbersResponse struct {
+	ErrorCode      string `json:"error-code,omitempty"`
+	ErrorCodeLabel string `json:"error-code-label,omitempty"`
+}
+
 // NumbersErrorResponse is the error format for the Numbers API
 type NumbersErrorResponse struct {
 	ErrorCode      string `json:"error-code,omitempty"`
@@ -220,7 +226,7 @@ type NumberBuyOpts struct {
 }
 
 // Buy the best phone number to use in your app
-func (client *NumbersClient) Buy(country string, msisdn string, opts NumberBuyOpts) (number.Response, NumbersErrorResponse, error) {
+func (client *NumbersClient) Buy(country string, msisdn string, opts NumberBuyOpts) (NumbersResponse, NumbersErrorResponse, error) {
 
 	numbersClient := number.NewAPIClient(client.Config)
 
@@ -248,15 +254,15 @@ func (client *NumbersClient) Buy(country string, msisdn string, opts NumberBuyOp
 			if errResp.ErrorCode == "420" && errResp.ErrorCodeLabel == "method failed" {
 				errResp.ErrorCodeLabel = "method failed. This can also indicate that you already own this number"
 			}
-			return result, errResp, nil
+			return NumbersResponse(result), errResp, nil
 		}
 	}
 
 	if err != nil {
-		return number.Response{}, NumbersErrorResponse{}, err
+		return NumbersResponse{}, NumbersErrorResponse{}, err
 	}
 
-	return result, NumbersErrorResponse{}, nil
+	return NumbersResponse(result), NumbersErrorResponse{}, nil
 }
 
 // NumberCancelOpts enables users to set the Target API Key (and any future params)
@@ -265,7 +271,7 @@ type NumberCancelOpts struct {
 }
 
 // Cancel a number already in your account
-func (client *NumbersClient) Cancel(country string, msisdn string, opts NumberCancelOpts) (number.Response, NumbersErrorResponse, error) {
+func (client *NumbersClient) Cancel(country string, msisdn string, opts NumberCancelOpts) (NumbersResponse, NumbersErrorResponse, error) {
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
@@ -292,15 +298,15 @@ func (client *NumbersClient) Cancel(country string, msisdn string, opts NumberCa
 				// expand on this error code, it's commonly because you don't own the number
 				errResp.ErrorCodeLabel = "method failed. This can also indicate that the number is not associated with this key"
 			}
-			return result, errResp, nil
+			return NumbersResponse(result), errResp, nil
 		}
 	}
 
 	if err != nil {
-		return number.Response{}, NumbersErrorResponse{}, err
+		return NumbersResponse{}, NumbersErrorResponse{}, err
 	}
 
-	return result, NumbersErrorResponse{}, nil
+	return NumbersResponse(result), NumbersErrorResponse{}, nil
 }
 
 // NumberUpdateOpts sets all the various fields for the number config
@@ -315,7 +321,7 @@ type NumberUpdateOpts struct {
 }
 
 // Update the configuration for your number
-func (client *NumbersClient) Update(country string, msisdn string, opts NumberUpdateOpts) (number.Response, NumbersErrorResponse, error) {
+func (client *NumbersClient) Update(country string, msisdn string, opts NumberUpdateOpts) (NumbersResponse, NumbersErrorResponse, error) {
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
@@ -347,7 +353,7 @@ func (client *NumbersClient) Update(country string, msisdn string, opts NumberUp
 
 	result, resp, err := numbersClient.DefaultApi.UpdateANumber(ctx, country, msisdn, &numbersUpdateOpts)
 	if err != nil {
-		return number.Response{}, NumbersErrorResponse{}, err
+		return NumbersResponse{}, NumbersErrorResponse{}, err
 	}
 
 	if resp.StatusCode != 200 {
@@ -358,9 +364,9 @@ func (client *NumbersClient) Update(country string, msisdn string, opts NumberUp
 		var errResp NumbersErrorResponse
 		jsonErr := json.Unmarshal(data, &errResp)
 		if jsonErr == nil {
-			return result, errResp, nil
+			return NumbersResponse(result), errResp, nil
 		}
 	}
 
-	return result, NumbersErrorResponse{}, nil
+	return NumbersResponse(result), NumbersErrorResponse{}, nil
 }

--- a/sms_test.go
+++ b/sms_test.go
@@ -43,9 +43,10 @@ func TestSmsSend(t *testing.T) {
 
 	auth := CreateAuthFromKeySecret("12345678", "456")
 	client := NewSMSClient(auth)
-	_, err := client.Send("44777000777", "44777000888", "hello", SMSOpts{})
+	result, _, _ := client.Send("44777000777", "44777000888", "hello", SMSOpts{})
 
-	if err != nil {
+	messageId := result.Messages[0].MessageId
+	if messageId != "0A0000000123ABCD1" {
 		t.Error("Test SMS not sent")
 	}
 }
@@ -61,7 +62,8 @@ func TestSmsSendFail(t *testing.T) {
 	  "message-count": "1",
 	  "messages": [
 	    {
-	      "status": "4"
+			"status": "4",
+			"error-text": "This is an error"
 	    }
 	  ]
 	}
@@ -75,9 +77,11 @@ func TestSmsSendFail(t *testing.T) {
 
 	auth := CreateAuthFromKeySecret("12345678", "456")
 	client := NewSMSClient(auth)
-	_, err := client.Send("44777000777", "44777000888", "hello", SMSOpts{})
+	_, errResp, _ := client.Send("44777000777", "44777000888", "hello", SMSOpts{})
 
-	if err == nil {
+	msg := errResp.Messages[0].ErrorText
+
+	if msg != "This is an error" {
 		t.Error("The failure failed")
 	}
 }


### PR DESCRIPTION
Most of the APIs have an error response type but SMS (was built first and) didn't. This adds that, and removes some of the dependencies on internal types.

Note: Breaking change! Needs to release as a minor version bump rather than a patch bump (because we're still pre-1.0)