### PR TITLE
Context overloads for all applicable methods

### DIFF
--- a/application.go
+++ b/application.go
@@ -61,6 +61,11 @@ type ApplicationResponseCollection struct {
 
 // List your Applications
 func (client *ApplicationClient) GetApplications(opts GetApplicationsOpts) (ApplicationResponseCollection, ApplicationErrorResponse, error) {
+	return client.GetApplicationsContext(context.Background(), opts)
+}
+
+// List your Applications
+func (client *ApplicationClient) GetApplicationsContext(ctx context.Context, opts GetApplicationsOpts) (ApplicationResponseCollection, ApplicationErrorResponse, error) {
 	// create the client
 	applicationClient := application.NewAPIClient(client.Config)
 
@@ -74,7 +79,7 @@ func (client *ApplicationClient) GetApplications(opts GetApplicationsOpts) (Appl
 		AppOpts.PageSize = optional.NewInt32(opts.PageSize)
 	}
 
-	ctx := context.WithValue(context.Background(), application.ContextBasicAuth, application.BasicAuth{
+	ctx = context.WithValue(ctx, application.ContextBasicAuth, application.BasicAuth{
 		UserName: client.apiKey,
 		Password: client.apiSecret,
 	})
@@ -112,10 +117,15 @@ func (client *ApplicationClient) GetApplications(opts GetApplicationsOpts) (Appl
 
 // GetApplication returns one application, by app ID
 func (client *ApplicationClient) GetApplication(app_id string) (ApplicationResponse, ApplicationErrorResponse, error) {
+	return client.GetApplicationContext(context.Background(), app_id)
+}
+
+// GetApplicationContext returns one application, by app ID
+func (client *ApplicationClient) GetApplicationContext(ctx context.Context, app_id string) (ApplicationResponse, ApplicationErrorResponse, error) {
 	// create the client
 	applicationClient := application.NewAPIClient(client.Config)
 
-	ctx := context.WithValue(context.Background(), application.ContextBasicAuth, application.BasicAuth{
+	ctx = context.WithValue(ctx, application.ContextBasicAuth, application.BasicAuth{
 		UserName: client.apiKey,
 		Password: client.apiSecret,
 	})
@@ -201,6 +211,11 @@ type CreateApplicationRequestOpts struct {
 
 // CreateApplication creates a new application
 func (client *ApplicationClient) CreateApplication(name string, opts CreateApplicationOpts) (ApplicationResponse, ApplicationErrorResponse, error) {
+	return client.CreateApplicationContext(context.Background(), name, opts)
+}
+
+// CreateApplicationContext creates a new application
+func (client *ApplicationClient) CreateApplicationContext(ctx context.Context, name string, opts CreateApplicationOpts) (ApplicationResponse, ApplicationErrorResponse, error) {
 	// create the client
 	applicationClient := application.NewAPIClient(client.Config)
 
@@ -215,7 +230,7 @@ func (client *ApplicationClient) CreateApplication(name string, opts CreateAppli
 
 	createOpts := application.CreateApplicationOpts{Opts: optional.NewInterface(AppOpts)}
 
-	ctx := context.WithValue(context.Background(), application.ContextBasicAuth, application.BasicAuth{
+	ctx = context.WithValue(ctx, application.ContextBasicAuth, application.BasicAuth{
 		UserName: client.apiKey,
 		Password: client.apiSecret,
 	})
@@ -240,10 +255,15 @@ func (client *ApplicationClient) CreateApplication(name string, opts CreateAppli
 
 // Delete application deletes an application
 func (client *ApplicationClient) DeleteApplication(app_id string) (bool, ApplicationErrorResponse, error) {
+	return client.DeleteApplicationContext(context.Background(), app_id)
+}
+
+// DeleteContext application deletes an application
+func (client *ApplicationClient) DeleteApplicationContext(ctx context.Context, app_id string) (bool, ApplicationErrorResponse, error) {
 	// create the client
 	applicationClient := application.NewAPIClient(client.Config)
 
-	ctx := context.WithValue(context.Background(), application.ContextBasicAuth, application.BasicAuth{
+	ctx = context.WithValue(ctx, application.ContextBasicAuth, application.BasicAuth{
 		UserName: client.apiKey,
 		Password: client.apiSecret,
 	})
@@ -282,6 +302,11 @@ type UpdateApplicationRequestOpts struct {
 
 // UpdateApplication updates an existing application
 func (client *ApplicationClient) UpdateApplication(id string, name string, opts UpdateApplicationOpts) (ApplicationResponse, ApplicationErrorResponse, error) {
+	return client.UpdateApplicationContext(context.Background(), id, name, opts)
+}
+
+// UpdateApplicationContext updates an existing application
+func (client *ApplicationClient) UpdateApplicationContext(ctx context.Context, id string, name string, opts UpdateApplicationOpts) (ApplicationResponse, ApplicationErrorResponse, error) {
 	// create the client
 	applicationClient := application.NewAPIClient(client.Config)
 
@@ -296,7 +321,7 @@ func (client *ApplicationClient) UpdateApplication(id string, name string, opts 
 
 	updateOpts := application.UpdateApplicationOpts{Opts: optional.NewInterface(AppOpts)}
 
-	ctx := context.WithValue(context.Background(), application.ContextBasicAuth, application.BasicAuth{
+	ctx = context.WithValue(ctx, application.ContextBasicAuth, application.BasicAuth{
 		UserName: client.apiKey,
 		Password: client.apiSecret,
 	})

--- a/number.go
+++ b/number.go
@@ -72,6 +72,11 @@ type NumberCollection struct {
 
 // List shows the numbers you already own, filters and pagination are available
 func (client *NumbersClient) List(opts NumbersOpts) (NumberCollection, NumbersErrorResponse, error) {
+	return client.ListContext(context.Background(), opts)
+}
+
+// ListContext shows the numbers you already own, filters and pagination are available
+func (client *NumbersClient) ListContext(ctx context.Context, opts NumbersOpts) (NumberCollection, NumbersErrorResponse, error) {
 
 	numbersClient := number.NewAPIClient(client.Config)
 
@@ -112,7 +117,7 @@ func (client *NumbersClient) List(opts NumbersOpts) (NumberCollection, NumbersEr
 	}
 
 	// we need context for the API key
-	ctx := context.WithValue(context.Background(), number.ContextAPIKey, number.APIKey{
+	ctx = context.WithValue(ctx, number.ContextAPIKey, number.APIKey{
 		Key: client.apiKey,
 	})
 
@@ -168,11 +173,16 @@ type NumberAvailable struct {
 
 // Search lets you find a great phone number to use in your application
 func (client *NumbersClient) Search(country string, opts NumberSearchOpts) (NumberSearch, NumbersErrorResponse, error) {
+	return client.SearchContext(context.Background(), country, opts)
+}
+
+// SearchContext lets you find a great phone number to use in your application
+func (client *NumbersClient) SearchContext(ctx context.Context, country string, opts NumberSearchOpts) (NumberSearch, NumbersErrorResponse, error) {
 
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
-	ctx := context.WithValue(context.Background(), number.ContextAPIKey, number.APIKey{
+	ctx = context.WithValue(ctx, number.ContextAPIKey, number.APIKey{
 		Key: client.apiKey,
 	})
 
@@ -227,11 +237,16 @@ type NumberBuyOpts struct {
 
 // Buy the best phone number to use in your app
 func (client *NumbersClient) Buy(country string, msisdn string, opts NumberBuyOpts) (NumbersResponse, NumbersErrorResponse, error) {
+	return client.BuyContext(context.Background(), country, msisdn, opts)
+}
+
+// BuyContext the best phone number to use in your app
+func (client *NumbersClient) BuyContext(ctx context.Context, country string, msisdn string, opts NumberBuyOpts) (NumbersResponse, NumbersErrorResponse, error) {
 
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
-	ctx := context.WithValue(context.Background(), number.ContextAPIKey, number.APIKey{
+	ctx = context.WithValue(ctx, number.ContextAPIKey, number.APIKey{
 		Key: client.apiKey,
 	})
 
@@ -272,10 +287,15 @@ type NumberCancelOpts struct {
 
 // Cancel a number already in your account
 func (client *NumbersClient) Cancel(country string, msisdn string, opts NumberCancelOpts) (NumbersResponse, NumbersErrorResponse, error) {
+	return client.CancelContext(context.Background(), country, msisdn, opts)
+}
+
+// CancelContext a number already in your account
+func (client *NumbersClient) CancelContext(ctx context.Context, country string, msisdn string, opts NumberCancelOpts) (NumbersResponse, NumbersErrorResponse, error) {
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
-	ctx := context.WithValue(context.Background(), number.ContextAPIKey, number.APIKey{
+	ctx = context.WithValue(ctx, number.ContextAPIKey, number.APIKey{
 		Key: client.apiKey,
 	})
 
@@ -322,10 +342,15 @@ type NumberUpdateOpts struct {
 
 // Update the configuration for your number
 func (client *NumbersClient) Update(country string, msisdn string, opts NumberUpdateOpts) (NumbersResponse, NumbersErrorResponse, error) {
+	return client.UpdateContext(context.Background(), country, msisdn, opts)
+}
+
+// UpdateContext the configuration for your number
+func (client *NumbersClient) UpdateContext(ctx context.Context, country string, msisdn string, opts NumberUpdateOpts) (NumbersResponse, NumbersErrorResponse, error) {
 	numbersClient := number.NewAPIClient(client.Config)
 
 	// we need context for the API key
-	ctx := context.WithValue(context.Background(), number.ContextAPIKey, number.APIKey{
+	ctx = context.WithValue(ctx, number.ContextAPIKey, number.APIKey{
 		Key: client.apiKey,
 	})
 

--- a/numberinsight.go
+++ b/numberinsight.go
@@ -49,6 +49,11 @@ type NiResponseJsonBasic struct {
 
 // Basic does a basic-level lookup for data about a number
 func (client *NumberInsightClient) Basic(number string, opts NiOpts) (NiResponseJsonBasic, NiErrorResponse, error) {
+	return client.BasicContext(context.Background(), number, opts)
+}
+
+// BasicContext does a basic-level lookup for data about a number
+func (client *NumberInsightClient) BasicContext(ctx context.Context, number string, opts NiOpts) (NiResponseJsonBasic, NiErrorResponse, error) {
 	// create the client
 	numberinsightClient := numberinsight.NewAPIClient(client.Config)
 
@@ -59,7 +64,6 @@ func (client *NumberInsightClient) Basic(number string, opts NiOpts) (NiResponse
 	}
 
 	// we need context for the API key
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, numberinsight.ContextAPIKey, numberinsight.APIKey{Key: client.apiKey})
 	ctx = context.WithValue(ctx, numberinsight.ContextAPISecret, numberinsight.APIKey{Key: client.apiSecret})
 
@@ -107,13 +111,17 @@ type NiResponseJsonStandard struct {
 
 // Standard does a Standard-level lookup for data about a number
 func (client *NumberInsightClient) Standard(number string, opts NiOpts) (NiResponseJsonStandard, NiErrorResponse, error) {
+	return client.StandardContext(context.Background(), number, opts)
+}
+
+// StandardContext does a Standard-level lookup for data about a number
+func (client *NumberInsightClient) StandardContext(ctx context.Context, number string, opts NiOpts) (NiResponseJsonStandard, NiErrorResponse, error) {
 	// create the client
 	numberinsightClient := numberinsight.NewAPIClient(client.Config)
 
 	niOpts := numberinsight.GetNumberInsightStandardOpts{}
 
 	// we need context for the API key
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, numberinsight.ContextAPIKey, numberinsight.APIKey{Key: client.apiKey})
 	ctx = context.WithValue(ctx, numberinsight.ContextAPISecret, numberinsight.APIKey{Key: client.apiSecret})
 
@@ -146,13 +154,17 @@ type NiResponseAsync struct {
 
 // AdvancedAsync requests a callback with advanced-level information about a number
 func (client *NumberInsightClient) AdvancedAsync(number string, callback string, opts NiOpts) (NiResponseAsync, NiErrorResponse, error) {
+	return client.AdvancedAsyncContext(context.Background(), number, callback, opts)
+}
+
+// AdvancedAsyncContext requests a callback with advanced-level information about a number
+func (client *NumberInsightClient) AdvancedAsyncContext(ctx context.Context, number string, callback string, opts NiOpts) (NiResponseAsync, NiErrorResponse, error) {
 	// create the client
 	numberinsightClient := numberinsight.NewAPIClient(client.Config)
 
 	niOpts := numberinsight.GetNumberInsightAsyncOpts{}
 
 	// we need context for the API key
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, numberinsight.ContextAPIKey, numberinsight.APIKey{Key: client.apiKey})
 	ctx = context.WithValue(ctx, numberinsight.ContextAPISecret, numberinsight.APIKey{Key: client.apiSecret})
 

--- a/sms.go
+++ b/sms.go
@@ -57,6 +57,13 @@ type SmsError struct {
 // some restrictions on what you can send from, to be safe try using a Vonage
 // number associated with your account
 func (client *SMSClient) Send(from string, to string, text string, opts SMSOpts) (Sms, SmsErrorResponse, error) {
+	return client.SendContext(context.Background(), from, to, text, opts)
+}
+
+// SendContext an SMS. Give some text to send and the number to send to - there are
+// some restrictions on what you can send from, to be safe try using a Vonage
+// number associated with your account
+func (client *SMSClient) SendContext(ctx context.Context, from string, to string, text string, opts SMSOpts) (Sms, SmsErrorResponse, error) {
 
 	smsClient := sms.NewAPIClient(client.Config)
 
@@ -80,8 +87,6 @@ func (client *SMSClient) Send(from string, to string, text string, opts SMSOpts)
 	if opts.StatusReportReq {
 		smsOpts.StatusReportReq = optional.NewBool(opts.StatusReportReq)
 	}
-
-	ctx := context.Background()
 
 	// now send the SMS
 	result, resp, err := smsClient.DefaultApi.SendAnSms(ctx, "json", client.apiKey, from, to, &smsOpts)

--- a/verify.go
+++ b/verify.go
@@ -53,6 +53,11 @@ type VerifyErrorResponse struct {
 
 // Request a number is verified for ownership
 func (client *VerifyClient) Request(number string, brand string, opts VerifyOpts) (VerifyRequestResponse, VerifyErrorResponse, error) {
+	return client.RequestContext(context.Background(), number, brand, opts)
+}
+
+// RequestContext a number is verified for ownership
+func (client *VerifyClient) RequestContext(ctx context.Context, number string, brand string, opts VerifyOpts) (VerifyRequestResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
@@ -75,7 +80,6 @@ func (client *VerifyClient) Request(number string, brand string, opts VerifyOpts
 		verifyOpts.SenderId = optional.NewString(opts.SenderID)
 	}
 
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifyRequest(ctx, "json", client.apiKey, client.apiSecret, number, brand, &verifyOpts)
 
 	// catch HTTP errors
@@ -107,12 +111,16 @@ type VerifyCheckResponse struct {
 
 // Check the user-supplied code for this request ID
 func (client *VerifyClient) Check(requestID string, code string) (VerifyCheckResponse, VerifyErrorResponse, error) {
+	return client.CheckContext(context.Background(), requestID, code)
+}
+
+// CheckContext the user-supplied code for this request ID
+func (client *VerifyClient) CheckContext(ctx context.Context, requestID string, code string) (VerifyCheckResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
 	// set up and then parse the options
 	verifyOpts := verify.VerifyCheckOpts{}
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifyCheck(ctx, "json", client.apiKey, client.apiSecret, requestID, code, &verifyOpts)
 
 	// catch HTTP errors
@@ -153,13 +161,17 @@ type VerifySearchResponse struct {
 
 // Search for an earlier request by id
 func (client *VerifyClient) Search(requestID string) (VerifySearchResponse, VerifyErrorResponse, error) {
+	return client.SearchContext(context.Background(), requestID)
+}
+
+// SearchContext for an earlier request by id
+func (client *VerifyClient) SearchContext(ctx context.Context, requestID string) (VerifySearchResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
 	// set up and then parse the options
 	verifyOpts := verify.VerifySearchOpts{}
 	verifyOpts.RequestId = optional.NewString(requestID)
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifySearch(ctx, "json", client.apiKey, client.apiSecret, &verifyOpts)
 
 	// catch HTTP errors
@@ -188,10 +200,14 @@ type VerifyControlResponse struct {
 
 // Cancel an in-progress request (check API docs for when this is possible)
 func (client *VerifyClient) Cancel(requestID string) (VerifyControlResponse, VerifyErrorResponse, error) {
+	return client.CancelContext(context.Background(), requestID)
+}
+
+// CancelContext an in-progress request (check API docs for when this is possible)
+func (client *VerifyClient) CancelContext(ctx context.Context, requestID string) (VerifyControlResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifyControl(ctx, "json", client.apiKey, client.apiSecret, requestID, "cancel")
 
 	// catch HTTP errors
@@ -215,10 +231,14 @@ func (client *VerifyClient) Cancel(requestID string) (VerifyControlResponse, Ver
 
 // TriggerNextEvent moves on to the next event in the workflow
 func (client *VerifyClient) TriggerNextEvent(requestID string) (VerifyControlResponse, VerifyErrorResponse, error) {
+	return client.TriggerNextEventContext(context.Background(), requestID)
+}
+
+// TriggerNextEventContext moves on to the next event in the workflow
+func (client *VerifyClient) TriggerNextEventContext(ctx context.Context, requestID string) (VerifyControlResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifyControl(ctx, "json", client.apiKey, client.apiSecret, requestID, "trigger_next_event")
 
 	// catch HTTP errors
@@ -252,6 +272,11 @@ type VerifyPsd2Opts struct {
 
 // Psd2 requests a user confirm a payment with amount and payee
 func (client *VerifyClient) Psd2(number string, payee string, amount float64, opts VerifyPsd2Opts) (VerifyRequestResponse, VerifyErrorResponse, error) {
+	return client.Psd2Context(context.Background(), number, payee, amount, opts)
+}
+
+// Psd2Context requests a user confirm a payment with amount and payee
+func (client *VerifyClient) Psd2Context(ctx context.Context, number string, payee string, amount float64, opts VerifyPsd2Opts) (VerifyRequestResponse, VerifyErrorResponse, error) {
 	// create the client
 	verifyClient := verify.NewAPIClient(client.Config)
 
@@ -270,7 +295,6 @@ func (client *VerifyClient) Psd2(number string, payee string, amount float64, op
 		verifyOpts.WorkflowId = optional.NewInt32(opts.WorkflowID)
 	}
 
-	ctx := context.Background()
 	result, resp, err := verifyClient.DefaultApi.VerifyRequestWithPSD2(ctx, "json", client.apiKey, client.apiSecret, number, payee, float32(amount), &verifyOpts)
 
 	// catch HTTP errors

--- a/voice.go
+++ b/voice.go
@@ -30,13 +30,17 @@ func NewVoiceClient(Auth Auth) *VoiceClient {
 
 // List your calls
 func (client *VoiceClient) GetCalls() (voice.GetCallsResponse, VoiceErrorResponse, error) {
+	return client.GetCallsContext(context.Background())
+}
+
+// List your calls
+func (client *VoiceClient) GetCallsContext(ctx context.Context) (voice.GetCallsResponse, VoiceErrorResponse, error) {
 	// create the client
 	voiceClient := voice.NewAPIClient(client.Config)
 
 	// set up and then parse the options
 	voiceOpts := voice.GetCallsOpts{}
 
-	ctx := context.Background()
 	result, _, err := voiceClient.CallsApi.GetCalls(ctx, &voiceOpts)
 
 	// catch HTTP errors
@@ -49,10 +53,14 @@ func (client *VoiceClient) GetCalls() (voice.GetCallsResponse, VoiceErrorRespons
 
 // GetCall for the details of a specific call
 func (client *VoiceClient) GetCall(uuid string) (voice.GetCallResponse, VoiceErrorResponse, error) {
+	return client.GetCallContext(context.Background(), uuid)
+}
+
+// GetCallContext for the details of a specific call
+func (client *VoiceClient) GetCallContext(ctx context.Context, uuid string) (voice.GetCallResponse, VoiceErrorResponse, error) {
 	// create the client
 	voiceClient := voice.NewAPIClient(client.Config)
 
-	ctx := context.Background()
 	result, _, err := voiceClient.CallsApi.GetCall(ctx, uuid)
 
 	// catch HTTP errors
@@ -155,6 +163,11 @@ func (client *VoiceClient) createCallCommon(opts CreateCallOpts) voice.CreateCal
 
 // CreateCall Makes a phone call given the from/to details and an NCCO or an Answer URL
 func (client *VoiceClient) CreateCall(opts CreateCallOpts) (voice.CreateCallResponse, VoiceErrorResponse, error) {
+	return client.CreateCallContext(context.Background(), opts)
+}
+
+// CreateCallContext Makes a phone call given the from/to details and an NCCO or an Answer URL
+func (client *VoiceClient) CreateCallContext(ctx context.Context, opts CreateCallOpts) (voice.CreateCallResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
 	// use the same validation regardless of which type of call this is
 	commonFields := client.createCallCommon(opts)
@@ -176,7 +189,6 @@ func (client *VoiceClient) CreateCall(opts CreateCallOpts) (voice.CreateCallResp
 
 		callOpts := optional.NewInterface(voiceCallOpts)
 
-		ctx := context.Background()
 		createCallOpts := &voice.CreateCallOpts{Opts: callOpts}
 		NccoResult, _, NccoErr := voiceClient.CallsApi.CreateCall(ctx, createCallOpts)
 		return client.handleCreateCallErrors(NccoResult, NccoErr)
@@ -199,7 +211,6 @@ func (client *VoiceClient) CreateCall(opts CreateCallOpts) (voice.CreateCallResp
 
 		callOpts := optional.NewInterface(voiceCallOpts)
 
-		ctx := context.Background()
 		createCallOpts := &voice.CreateCallOpts{Opts: callOpts}
 		AnswerResult, _, AnswerErr := voiceClient.CallsApi.CreateCall(ctx, createCallOpts)
 		return client.handleCreateCallErrors(AnswerResult, AnswerErr)
@@ -275,6 +286,11 @@ type TransferWithNccoOpts struct {
 
 // TransferCall wraps the Modify Call API endpoint
 func (client *VoiceClient) TransferCall(opts TransferCallOpts) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.TransferCallContext(context.Background(), opts)
+}
+
+// TransferCallContext wraps the Modify Call API endpoint
+func (client *VoiceClient) TransferCallContext(ctx context.Context, opts TransferCallOpts) (ModifyCallResponse, VoiceErrorResponse, error) {
 	// create the client
 	voiceClient := voice.NewAPIClient(client.Config)
 
@@ -282,7 +298,6 @@ func (client *VoiceClient) TransferCall(opts TransferCallOpts) (ModifyCallRespon
 		destination := TransferDestinationUrl{Type: "ncco", Url: opts.AnswerUrl}
 		transfer := TransferWithUrlOpts{Action: "transfer", Destination: destination}
 		modifyCallOpts := voice.ModifyCallOpts{Opts: optional.NewInterface(transfer)}
-		ctx := context.Background()
 		response, err := voiceClient.CallsApi.UpdateCall(ctx, opts.Uuid, &modifyCallOpts)
 		if err != nil {
 			e := err.(voice.GenericOpenAPIError)
@@ -304,7 +319,6 @@ func (client *VoiceClient) TransferCall(opts TransferCallOpts) (ModifyCallRespon
 		destination := TransferDestinationNcco{Type: "ncco", Ncco: opts.Ncco}
 		transfer := TransferWithNccoOpts{Action: "transfer", Destination: destination}
 		modifyCallOpts := voice.ModifyCallOpts{Opts: optional.NewInterface(transfer)}
-		ctx := context.Background()
 		response, err := voiceClient.CallsApi.UpdateCall(ctx, opts.Uuid, &modifyCallOpts)
 		if err != nil {
 			e := err.(voice.GenericOpenAPIError)
@@ -334,35 +348,59 @@ type ModifyCallOpts struct {
 
 // Hangup wraps the Modify Call API endpoint
 func (client *VoiceClient) Hangup(uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
-	return client.voiceAction("hangup", uuid)
+	return client.voiceAction(context.Background(), "hangup", uuid)
+}
+
+// HangupContext wraps the Modify Call API endpoint
+func (client *VoiceClient) HangupContext(ctx context.Context, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.voiceAction(ctx, "hangup", uuid)
 }
 
 // Mute wraps the Modify Call API endpoint
 func (client *VoiceClient) Mute(uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
-	return client.voiceAction("mute", uuid)
+	return client.voiceAction(context.Background(), "mute", uuid)
+}
+
+// MuteContext wraps the Modify Call API endpoint
+func (client *VoiceClient) MuteContext(ctx context.Context, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.voiceAction(ctx, "mute", uuid)
 }
 
 // Unmute wraps the Modify Call API endpoint
 func (client *VoiceClient) Unmute(uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
-	return client.voiceAction("unmute", uuid)
+	return client.voiceAction(context.Background(), "unmute", uuid)
+}
+
+// UnmuteContext wraps the Modify Call API endpoint
+func (client *VoiceClient) UnmuteContext(ctx context.Context, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.voiceAction(ctx, "unmute", uuid)
 }
 
 // Earmuff wraps the Modify Call API endpoint
 func (client *VoiceClient) Earmuff(uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
-	return client.voiceAction("earmuff", uuid)
+	return client.voiceAction(context.Background(), "earmuff", uuid)
+}
+
+// EarmuffContext wraps the Modify Call API endpoint
+func (client *VoiceClient) EarmuffContext(ctx context.Context, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.voiceAction(ctx, "earmuff", uuid)
 }
 
 // Unearmuff wraps the Modify Call API endpoint
 func (client *VoiceClient) Unearmuff(uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
-	return client.voiceAction("unearmuff", uuid)
+	return client.voiceAction(context.Background(), "unearmuff", uuid)
+}
+
+// UnearmuffContext wraps the Modify Call API endpoint
+func (client *VoiceClient) UnearmuffContext(ctx context.Context, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+	return client.voiceAction(ctx, "unearmuff", uuid)
 }
 
 // voiceAction holds the code for the actions that have no extra params
-func (client *VoiceClient) voiceAction(action string, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
+func (client *VoiceClient) voiceAction(ctx context.Context, action string, uuid string) (ModifyCallResponse, VoiceErrorResponse, error) {
 	// create the client
 	voiceClient := voice.NewAPIClient(client.Config)
 	modifyCallOpts := voice.ModifyCallOpts{Opts: optional.NewInterface(ModifyCallOpts{Action: action})}
-	ctx := context.Background()
 
 	response, err := voiceClient.CallsApi.UpdateCall(ctx, uuid, &modifyCallOpts)
 	if err != nil {
@@ -390,11 +428,15 @@ type PlayAudioOpts struct {
 
 // PlayAudioStream starts an audio file from a URL playing in a call
 func (client *VoiceClient) PlayAudioStream(uuid string, streamUrl string, opts PlayAudioOpts) (voice.StartStreamResponse, VoiceErrorResponse, error) {
+	return client.PlayAudioStreamContext(context.Background(), uuid, streamUrl, opts)
+}
+
+// PlayAudioStreamContext starts an audio file from a URL playing in a call
+func (client *VoiceClient) PlayAudioStreamContext(ctx context.Context, uuid string, streamUrl string, opts PlayAudioOpts) (voice.StartStreamResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
 
 	streamOpts := voice.StartStreamRequest{StreamUrl: []string{streamUrl}}
 
-	ctx := context.Background()
 	response, _, err := voiceClient.StreamAudioApi.StartStream(ctx, uuid, streamOpts)
 
 	if err != nil {
@@ -413,8 +455,12 @@ func (client *VoiceClient) PlayAudioStream(uuid string, streamUrl string, opts P
 
 // StopAudioStream stops the currently-playing audio stream
 func (client *VoiceClient) StopAudioStream(uuid string) (voice.StopStreamResponse, VoiceErrorResponse, error) {
+	return client.StopAudioStreamContext(context.Background(), uuid)
+}
+
+// StopAudioStreamContext stops the currently-playing audio stream
+func (client *VoiceClient) StopAudioStreamContext(ctx context.Context, uuid string) (voice.StopStreamResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
-	ctx := context.Background()
 	response, _, err := voiceClient.StreamAudioApi.StopStream(ctx, uuid)
 
 	if err != nil {
@@ -440,6 +486,11 @@ type PlayTtsOpts struct {
 
 // PlayTts starts playing TTS into the call
 func (client *VoiceClient) PlayTts(uuid string, text string, opts PlayTtsOpts) (voice.StartTalkResponse, VoiceErrorResponse, error) {
+	return client.PlayTtsContext(context.Background(), uuid, text, opts)
+}
+
+// PlayTtsContext starts playing TTS into the call
+func (client *VoiceClient) PlayTtsContext(ctx context.Context, uuid string, text string, opts PlayTtsOpts) (voice.StartTalkResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
 
 	req_vars := voice.StartTalkRequest{Text: text}
@@ -454,7 +505,6 @@ func (client *VoiceClient) PlayTts(uuid string, text string, opts PlayTtsOpts) (
 	}
 	talkOpts := voice.StartTalkOpts{StartTalkRequest: optional.NewInterface(req_vars)}
 
-	ctx := context.Background()
 	response, _, err := voiceClient.PlayTTSApi.StartTalk(ctx, uuid, &talkOpts)
 
 	if err != nil {
@@ -473,8 +523,12 @@ func (client *VoiceClient) PlayTts(uuid string, text string, opts PlayTtsOpts) (
 
 // StopTts stops the current TTS from playing
 func (client *VoiceClient) StopTts(uuid string) (voice.StopTalkResponse, VoiceErrorResponse, error) {
+	return client.StopTtsContext(context.Background(), uuid)
+}
+
+// StopTtsContext stops the current TTS from playing
+func (client *VoiceClient) StopTtsContext(ctx context.Context, uuid string) (voice.StopTalkResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
-	ctx := context.Background()
 	response, _, err := voiceClient.PlayTTSApi.StopTalk(ctx, uuid)
 
 	if err != nil {
@@ -493,10 +547,14 @@ func (client *VoiceClient) StopTts(uuid string) (voice.StopTalkResponse, VoiceEr
 
 // PlayDTMF starts playing a string of DTMF digits into the call
 func (client *VoiceClient) PlayDtmf(uuid string, dtmf string) (voice.DtmfResponse, VoiceErrorResponse, error) {
+	return client.PlayDtmfContext(context.Background(), uuid, dtmf)
+}
+
+// PlayDTMFContext starts playing a string of DTMF digits into the call
+func (client *VoiceClient) PlayDtmfContext(ctx context.Context, uuid string, dtmf string) (voice.DtmfResponse, VoiceErrorResponse, error) {
 	voiceClient := voice.NewAPIClient(client.Config)
 	dtmfOpts := voice.DtmfRequest{Digits: dtmf}
 
-	ctx := context.Background()
 	response, _, err := voiceClient.PlayDTMFApi.StartDTMF(ctx, uuid, dtmfOpts)
 
 	if err != nil {


### PR DESCRIPTION
This PR adds `*Context` versions of all public methods.

The ability to propagate context is really important in apps that instrument their external dependencies to support additional logging metadata, tracing (eg [OTEL](https://opentelemetry.io)), and metrics (eg Prometheus).